### PR TITLE
#1 feat: 상담 신청 기능 구현

### DIFF
--- a/src/main/java/com/example/sharemind/consult/application/ConsultService.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultService.java
@@ -1,0 +1,10 @@
+package com.example.sharemind.consult.application;
+
+import com.example.sharemind.consult.dto.request.CreateConsultRequest;
+
+import java.util.UUID;
+
+public interface ConsultService {
+
+    UUID createConsult(CreateConsultRequest createConsultRequest);
+}

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -1,0 +1,36 @@
+package com.example.sharemind.consult.application;
+
+import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.consult.dto.request.CreateConsultRequest;
+import com.example.sharemind.consult.repository.ConsultRepository;
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.counselor.exception.CounselorNotFoundException;
+import com.example.sharemind.counselor.repository.CounselorRepository;
+import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.customer.repository.CustomerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ConsultServiceImpl implements ConsultService {
+
+    private final CustomerRepository customerRepository;
+    private final CounselorRepository counselorRepository;
+    private final ConsultRepository consultRepository;
+
+    @Override
+    public UUID createConsult(CreateConsultRequest createConsultRequest) {
+
+        Counselor counselor = counselorRepository.findById(createConsultRequest.getCounselorId())
+                .orElseThrow(() -> new CounselorNotFoundException(createConsultRequest.getCounselorId()));
+
+        Customer customer = customerRepository.save(createConsultRequest.toCustomer());
+
+        Consult consult = consultRepository.save(createConsultRequest.toConsult(customer, counselor));
+
+        return consult.getConsultUuid();
+    }
+}

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -18,6 +18,7 @@ public class Consult extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "consult_id")
     private Long consultId;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/example/sharemind/consult/dto/request/CreateConsultRequest.java
+++ b/src/main/java/com/example/sharemind/consult/dto/request/CreateConsultRequest.java
@@ -1,0 +1,42 @@
+package com.example.sharemind.consult.dto.request;
+
+import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.customer.domain.Customer;
+import lombok.Getter;
+
+import java.util.Random;
+import java.util.UUID;
+
+@Getter
+public class CreateConsultRequest {
+
+    private Long counselorId;
+    private String email;
+    private String name;
+    private String phoneNumber;
+    private String accountNumber;
+    private String password;
+
+    public Customer toCustomer() {
+        return Customer.builder()
+                .nickname("사용자" + new Random().nextInt(9999))
+                .email(email)
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .accountNumber(accountNumber)
+                .build();
+    }
+
+    public Consult toConsult(Customer customer, Counselor counselor) {
+        return Consult.builder()
+                .customer(customer)
+                .counselor(counselor)
+                .consultUuid(UUID.randomUUID())
+                .password(password)
+                .isPay(false)
+                .isRefund(false)
+                .isReply(false)
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
+++ b/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
@@ -1,0 +1,23 @@
+package com.example.sharemind.consult.presentation;
+
+import com.example.sharemind.consult.application.ConsultService;
+import com.example.sharemind.consult.dto.request.CreateConsultRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v0/consult")
+@RequiredArgsConstructor
+public class ConsultController {
+
+    private final ConsultService consultService;
+
+    @PostMapping
+    public ResponseEntity<UUID> createConsult(@RequestBody CreateConsultRequest createConsultRequest) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(consultService.createConsult(createConsultRequest));
+    }
+}

--- a/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
+++ b/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
@@ -1,0 +1,9 @@
+package com.example.sharemind.consult.repository;
+
+import com.example.sharemind.consult.domain.Consult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConsultRepository extends JpaRepository<Consult, Long> {
+}

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
@@ -1,0 +1,8 @@
+package com.example.sharemind.counselor.application;
+
+import com.example.sharemind.counselor.dto.response.CounselorResponse;
+
+public interface CounselorService {
+
+    CounselorResponse getCounselor(Long counselorId);
+}

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -1,0 +1,24 @@
+package com.example.sharemind.counselor.application;
+
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.counselor.dto.response.CounselorResponse;
+import com.example.sharemind.counselor.exception.CounselorNotFoundException;
+import com.example.sharemind.counselor.repository.CounselorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CounselorServiceImpl implements CounselorService {
+
+    private final CounselorRepository counselorRepository;
+
+    @Override
+    public CounselorResponse getCounselor(Long counselorId) {
+
+        Counselor counselor = counselorRepository.findById(counselorId)
+                .orElseThrow(() -> new CounselorNotFoundException(counselorId));
+
+        return CounselorResponse.from(counselor);
+    }
+}

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -1,10 +1,7 @@
 package com.example.sharemind.counselor.domain;
 
 import com.example.sharemind.global.common.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,15 +14,25 @@ public class Counselor extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "counselor_id")
     private Long counselorId;
-
-    private String email;
 
     private String nickname;
 
+    private String email;
+
+    private String name;
+
+    private String phoneNumber;
+
+    private String accountNumber;
+
     @Builder
-    public Counselor(String email, String nickname) {
-        this.email = email;
+    public Counselor(String nickname, String email, String name, String phoneNumber, String accountNumber) {
         this.nickname = nickname;
+        this.email = email;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.accountNumber = accountNumber;
     }
 }

--- a/src/main/java/com/example/sharemind/counselor/dto/response/CounselorResponse.java
+++ b/src/main/java/com/example/sharemind/counselor/dto/response/CounselorResponse.java
@@ -1,0 +1,26 @@
+package com.example.sharemind.counselor.dto.response;
+
+import com.example.sharemind.counselor.domain.Counselor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CounselorResponse {
+
+    private final Long counselorId;
+
+    private final String nickname;
+
+    @Builder
+    public CounselorResponse(Long counselorId, String nickname) {
+        this.counselorId = counselorId;
+        this.nickname = nickname;
+    }
+
+    public static CounselorResponse from(Counselor counselor) {
+        return CounselorResponse.builder()
+                .counselorId(counselor.getCounselorId())
+                .nickname(counselor.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/counselor/dto/response/CounselorResponse.java
+++ b/src/main/java/com/example/sharemind/counselor/dto/response/CounselorResponse.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 public class CounselorResponse {
 
     private final Long counselorId;
-
     private final String nickname;
 
     @Builder

--- a/src/main/java/com/example/sharemind/counselor/exception/CounselorNotFoundException.java
+++ b/src/main/java/com/example/sharemind/counselor/exception/CounselorNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.sharemind.counselor.exception;
+
+public class CounselorNotFoundException extends RuntimeException {
+
+    public CounselorNotFoundException(Long counselorId) {
+        super("요청한 아이디에 해당하는 상담사 정보를 찾을 수 없습니다 : " + counselorId);
+    }
+}

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -1,0 +1,23 @@
+package com.example.sharemind.counselor.presentation;
+
+import com.example.sharemind.counselor.application.CounselorService;
+import com.example.sharemind.counselor.dto.response.CounselorResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v0/counselor")
+@RequiredArgsConstructor
+public class CounselorController {
+
+    private final CounselorService counselorService;
+
+    @GetMapping("/{counselorId}")
+    public ResponseEntity<CounselorResponse> getCounselor(@PathVariable Long counselorId) {
+        return ResponseEntity.ok(counselorService.getCounselor(counselorId));
+    }
+}

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorExceptionController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorExceptionController.java
@@ -1,0 +1,21 @@
+package com.example.sharemind.counselor.presentation;
+
+import com.example.sharemind.counselor.exception.CounselorNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class CounselorExceptionController {
+
+    @ExceptionHandler(CounselorNotFoundException.class)
+    public ResponseEntity<String> catchCounselorNotFoundException(CounselorNotFoundException e) {
+
+        log.error(e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+}

--- a/src/main/java/com/example/sharemind/counselor/repository/CounselorRepository.java
+++ b/src/main/java/com/example/sharemind/counselor/repository/CounselorRepository.java
@@ -1,0 +1,9 @@
+package com.example.sharemind.counselor.repository;
+
+import com.example.sharemind.counselor.domain.Counselor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CounselorRepository extends JpaRepository<Counselor, Long> {
+}

--- a/src/main/java/com/example/sharemind/customer/domain/Customer.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Customer.java
@@ -1,10 +1,7 @@
 package com.example.sharemind.customer.domain;
 
 import com.example.sharemind.global.common.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,15 +14,25 @@ public class Customer extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "customer_id")
     private Long customerId;
-
-    private String email;
 
     private String nickname;
 
+    private String email;
+
+    private String name;
+
+    private String phoneNumber;
+
+    private String accountNumber;
+
     @Builder
-    public Customer(String email, String nickname) {
-        this.email = email;
+    public Customer(String nickname, String email, String name, String phoneNumber, String accountNumber) {
         this.nickname = nickname;
+        this.email = email;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.accountNumber = accountNumber;
     }
 }

--- a/src/main/java/com/example/sharemind/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/example/sharemind/customer/repository/CustomerRepository.java
@@ -1,0 +1,9 @@
+package com.example.sharemind.customer.repository;
+
+import com.example.sharemind.customer.domain.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+}


### PR DESCRIPTION
## 📄구현 내용
- 노션에서 상담 신청 시 접속할 화면에 필요한 상담사 정보(아이디, 닉네임) 조회 API
- 상담 신청 API

## 📝기타 알림사항
- 노션 API 문서에 자세한 구현 내용 작성해두었습니다.
- 현재 결제 API 구현 보류 중으로, 상담 신청 후 플로우가 애매한 상황입니다. 일단 상담 신청 후 결제 완료 화면으로 넘어가는 것으로 가정하여 상담 링크에 해당하는 uuid 반환하도록 구현하였습니다. 
- 기획 파트에 counselor, customer에 추가로 저장할 정보 문의 후 답변받은 내용에 따라 erd와 엔티티 구현에 반영하였습니다.
- 커밋 메시지에 이슈 번호 포함하는 것을 까먹었습니다. 다음부터 추가하도록 하겠습니다.