### PR TITLE
#1 feat: 상담 비밀번호 확인 기능 구현

### DIFF
--- a/src/main/java/com/example/sharemind/consult/application/ConsultService.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultService.java
@@ -3,7 +3,11 @@ package com.example.sharemind.consult.application;
 import java.util.UUID;
 
 import com.example.sharemind.consult.dto.request.CreateConsultRequest;
+import com.example.sharemind.consult.dto.request.GetConsultRequest;
+import com.example.sharemind.consult.dto.response.ConsultResponse;
 
 public interface ConsultService {
     UUID createConsult(CreateConsultRequest createConsultRequest);
+
+    ConsultResponse getConsult(UUID consultUuid, GetConsultRequest getConsultRequest);
 }

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -2,15 +2,22 @@ package com.example.sharemind.consult.application;
 
 import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.consult.dto.request.CreateConsultRequest;
+import com.example.sharemind.consult.dto.request.GetConsultRequest;
+import com.example.sharemind.consult.dto.response.ConsultResponse;
+import com.example.sharemind.consult.exception.ConsultNotFoundException;
+import com.example.sharemind.consult.exception.IncorrectPasswordException;
 import com.example.sharemind.consult.repository.ConsultRepository;
 import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.counselor.exception.CounselorNotFoundException;
 import com.example.sharemind.counselor.repository.CounselorRepository;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.customer.repository.CustomerRepository;
+import com.example.sharemind.message.dto.response.MessageResponse;
+import com.example.sharemind.message.repository.MessageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -20,6 +27,7 @@ public class ConsultServiceImpl implements ConsultService {
     private final CustomerRepository customerRepository;
     private final CounselorRepository counselorRepository;
     private final ConsultRepository consultRepository;
+    private final MessageRepository messageRepository;
 
     @Override
     public UUID createConsult(CreateConsultRequest createConsultRequest) {
@@ -32,5 +40,23 @@ public class ConsultServiceImpl implements ConsultService {
         Consult consult = consultRepository.save(createConsultRequest.toConsult(customer, counselor));
 
         return consult.getConsultUuid();
+    }
+
+    @Override
+    public ConsultResponse getConsult(UUID consultUuid, GetConsultRequest getConsultRequest) {
+
+        Consult consult = consultRepository.findByConsultUuid(consultUuid)
+                .orElseThrow(() -> new ConsultNotFoundException(consultUuid));
+
+        if (!consult.getPassword().equals(getConsultRequest.getPassword())) {
+            throw new IncorrectPasswordException();
+        }
+
+        List<MessageResponse> messageResponses = messageRepository.findAllByConsult(consult)
+                .stream()
+                .map(MessageResponse::from)
+                .toList();
+
+        return ConsultResponse.from(consult, messageResponses);
     }
 }

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -16,11 +16,13 @@ import com.example.sharemind.message.dto.response.MessageResponse;
 import com.example.sharemind.message.repository.MessageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ConsultServiceImpl implements ConsultService {
 
@@ -30,6 +32,7 @@ public class ConsultServiceImpl implements ConsultService {
     private final MessageRepository messageRepository;
 
     @Override
+    @Transactional
     public UUID createConsult(CreateConsultRequest createConsultRequest) {
 
         Counselor counselor = counselorRepository.findById(createConsultRequest.getCounselorId())

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -45,7 +45,7 @@ public class ConsultServiceImpl implements ConsultService {
     @Override
     public ConsultResponse getConsult(UUID consultUuid, GetConsultRequest getConsultRequest) {
 
-        Consult consult = consultRepository.findByConsultUuid(consultUuid)
+        Consult consult = consultRepository.findByConsultUuidAndIsPay(consultUuid, true)
                 .orElseThrow(() -> new ConsultNotFoundException(consultUuid));
 
         if (!consult.getPassword().equals(getConsultRequest.getPassword())) {

--- a/src/main/java/com/example/sharemind/consult/dto/request/GetConsultRequest.java
+++ b/src/main/java/com/example/sharemind/consult/dto/request/GetConsultRequest.java
@@ -1,0 +1,9 @@
+package com.example.sharemind.consult.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class GetConsultRequest {
+
+    private String password;
+}

--- a/src/main/java/com/example/sharemind/consult/dto/response/ConsultResponse.java
+++ b/src/main/java/com/example/sharemind/consult/dto/response/ConsultResponse.java
@@ -1,0 +1,32 @@
+package com.example.sharemind.consult.dto.response;
+
+import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.message.dto.response.MessageResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ConsultResponse {
+
+    private final Long customerId;
+    private final Long counselorId;
+
+    private final List<MessageResponse> messageResponses;
+
+    @Builder
+    public ConsultResponse(Long customerId, Long counselorId, List<MessageResponse> messageResponses) {
+        this.customerId = customerId;
+        this.counselorId = counselorId;
+        this.messageResponses = messageResponses;
+    }
+
+    public static ConsultResponse from(Consult consult, List<MessageResponse> messageResponses) {
+        return ConsultResponse.builder()
+                .customerId(consult.getCustomer().getCustomerId())
+                .counselorId(consult.getCounselor().getCounselorId())
+                .messageResponses(messageResponses)
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/consult/exception/IncorrectPasswordException.java
+++ b/src/main/java/com/example/sharemind/consult/exception/IncorrectPasswordException.java
@@ -1,0 +1,8 @@
+package com.example.sharemind.consult.exception;
+
+public class IncorrectPasswordException extends RuntimeException {
+
+    public IncorrectPasswordException() {
+        super("비밀번호가 올바르지 않습니다.");
+    }
+}

--- a/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
+++ b/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
@@ -3,6 +3,8 @@ package com.example.sharemind.consult.presentation;
 import com.example.sharemind.consult.application.ConsultService;
 import com.example.sharemind.consult.application.EmailService;
 import com.example.sharemind.consult.dto.request.CreateConsultRequest;
+import com.example.sharemind.consult.dto.request.GetConsultRequest;
+import com.example.sharemind.consult.dto.response.ConsultResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +23,11 @@ public class ConsultController {
     @PostMapping
     public ResponseEntity<UUID> createConsult(@RequestBody CreateConsultRequest createConsultRequest) {
         return ResponseEntity.status(HttpStatus.CREATED).body(consultService.createConsult(createConsultRequest));
+    }
+
+    @GetMapping("/{consultUuid}")
+    public ResponseEntity<ConsultResponse> getConsult(@PathVariable UUID consultUuid, @RequestBody GetConsultRequest getConsultRequest) {
+        return ResponseEntity.ok(consultService.getConsult(consultUuid, getConsultRequest));
     }
 
     @GetMapping("/email/{consult_uuid}")

--- a/src/main/java/com/example/sharemind/consult/presentation/ConsultExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/consult/presentation/ConsultExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.sharemind.consult.presentation;
 
 
 import com.example.sharemind.consult.exception.ConsultNotFoundException;
+import com.example.sharemind.consult.exception.IncorrectPasswordException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,8 +13,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class ConsultExceptionHandler {
     @ExceptionHandler(ConsultNotFoundException.class)
-    public ResponseEntity<String> catchChatNotFoundException(ConsultNotFoundException e) {
+    public ResponseEntity<String> catchConsultNotFoundException(ConsultNotFoundException e) {
         log.error(e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(IncorrectPasswordException.class)
+    public ResponseEntity<String> catchIncorrectPasswordException(IncorrectPasswordException e) {
+        log.error(e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
     }
 }

--- a/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
+++ b/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ConsultRepository extends JpaRepository<Consult, Long> {
     Optional<Consult> findByConsultUuid(UUID consultUuid);
+
+    Optional<Consult> findByConsultUuidAndIsPay(UUID consultUuid, Boolean isPay);
 }

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -6,8 +6,10 @@ import com.example.sharemind.counselor.exception.CounselorNotFoundException;
 import com.example.sharemind.counselor.repository.CounselorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CounselorServiceImpl implements CounselorService {
 

--- a/src/main/java/com/example/sharemind/message/application/MessageServiceImpl.java
+++ b/src/main/java/com/example/sharemind/message/application/MessageServiceImpl.java
@@ -25,7 +25,7 @@ public class MessageServiceImpl implements MessageService {
 
         Message message = Message.builder()
                 .consult(consult)
-                .isSender(messageRequest.getIsSender())
+                .isCustomer(messageRequest.getIsCustomer())
                 .content(messageRequest.getContent())
                 .build();
         messageRepository.save(message);

--- a/src/main/java/com/example/sharemind/message/domain/Message.java
+++ b/src/main/java/com/example/sharemind/message/domain/Message.java
@@ -21,15 +21,15 @@ public class Message extends BaseEntity {
     @JoinColumn(name = "consult_id")
     private Consult consult;
 
-    private Boolean isSender;
+    private Boolean isCustomer;
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
     @Builder
-    public Message(Consult consult, Boolean isSender, String content) {
+    public Message(Consult consult, Boolean isCustomer, String content) {
         this.consult = consult;
-        this.isSender = isSender;
+        this.isCustomer = isCustomer;
         this.content = content;
     }
 }

--- a/src/main/java/com/example/sharemind/message/dto/request/MessageRequest.java
+++ b/src/main/java/com/example/sharemind/message/dto/request/MessageRequest.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 public class MessageRequest {
     private UUID consultUuid;
-    private Boolean isSender;
+    private Boolean isCustomer;
     private String content;
 }

--- a/src/main/java/com/example/sharemind/message/dto/response/MessageResponse.java
+++ b/src/main/java/com/example/sharemind/message/dto/response/MessageResponse.java
@@ -1,0 +1,25 @@
+package com.example.sharemind.message.dto.response;
+
+import com.example.sharemind.message.domain.Message;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MessageResponse {
+
+    private final Boolean isSender;
+    private final String content;
+
+    @Builder
+    public MessageResponse(Boolean isSender, String content) {
+        this.isSender = isSender;
+        this.content = content;
+    }
+
+    public static MessageResponse from(Message message) {
+        return MessageResponse.builder()
+                .isSender(message.getIsSender())
+                .content(message.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/message/dto/response/MessageResponse.java
+++ b/src/main/java/com/example/sharemind/message/dto/response/MessageResponse.java
@@ -7,18 +7,18 @@ import lombok.Getter;
 @Getter
 public class MessageResponse {
 
-    private final Boolean isSender;
+    private final Boolean isCustomer;
     private final String content;
 
     @Builder
-    public MessageResponse(Boolean isSender, String content) {
-        this.isSender = isSender;
+    public MessageResponse(Boolean isCustomer, String content, LocalDateTime createdAt) {
+        this.isCustomer = isCustomer;
         this.content = content;
     }
 
     public static MessageResponse from(Message message) {
         return MessageResponse.builder()
-                .isSender(message.getIsSender())
+                .isCustomer(message.getIsCustomer())
                 .content(message.getContent())
                 .build();
     }

--- a/src/main/java/com/example/sharemind/message/dto/response/MessageResponse.java
+++ b/src/main/java/com/example/sharemind/message/dto/response/MessageResponse.java
@@ -4,22 +4,27 @@ import com.example.sharemind.message.domain.Message;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class MessageResponse {
 
     private final Boolean isCustomer;
     private final String content;
+    private final LocalDateTime createdAt;
 
     @Builder
     public MessageResponse(Boolean isCustomer, String content, LocalDateTime createdAt) {
         this.isCustomer = isCustomer;
         this.content = content;
+        this.createdAt = createdAt;
     }
 
     public static MessageResponse from(Message message) {
         return MessageResponse.builder()
                 .isCustomer(message.getIsCustomer())
                 .content(message.getContent())
+                .createdAt(message.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/example/sharemind/message/presentation/MessageController.java
+++ b/src/main/java/com/example/sharemind/message/presentation/MessageController.java
@@ -21,10 +21,10 @@ public class MessageController {
     @PostMapping
     public ResponseEntity<Void> createMessage(@RequestBody MessageRequest messageRequest) {
         messageService.saveMessage(messageRequest);
-        Boolean isSender = messageRequest.getIsSender();
-        if (Boolean.TRUE.equals(isSender)) {
+        Boolean isCustomer = messageRequest.getIsCustomer();
+        if (Boolean.TRUE.equals(isCustomer)) {
             emailService.notifyConsultationApply(messageRequest.getConsultUuid());
-        } else if (Boolean.FALSE.equals(isSender)) {
+        } else if (Boolean.FALSE.equals(isCustomer)) {
             emailService.notifyConsultationReply(messageRequest.getConsultUuid());
         }
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/com/example/sharemind/message/repository/MessageRepository.java
+++ b/src/main/java/com/example/sharemind/message/repository/MessageRepository.java
@@ -1,10 +1,14 @@
 package com.example.sharemind.message.repository;
 
+import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.message.domain.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
+    List<Message> findAllByConsult(Consult consult);
 }


### PR DESCRIPTION
## 📄구현 내용
- 상담 정보 조회 API

## 📝기타 알림사항
- 노션 API 문서에 자세한 구현 내용 작성해두었습니다.
- 플로우 상 비밀번호 확인 -> 대화방 입장이라고 생각하여 비밀번호 확인 후 맞다면 바로 대화 내용 리스트 반환하는 방식으로 구현하였습니다.
- GetConsultRequest에서 받는 정보가 password 뿐입니다. 필드가 하나 뿐이라 간단하게 requestParam으로 처리하고 싶었으나, 비밀번호가 민감한 정보라 주소에 노출하는 것은 적합하지 않다고 생각하여 이렇게 구현하였습니다. 혹시 더 좋은 의견 있다면 말씀해주세요!
- ConsultResponse, MessageResponse에는 프론트에서 필요할 것이라고 판단한 필드값들을 임의로 넣었습니다.
- Message의 isSender에서 true, false에 따라 작성자(상담사/사용자)를 저희끼리 임의로 정해두었는데, isSender가 프론트에도 넘어가는 값이라 변수명이 더 명확하면 좋을 것 같다는 생각이 들었습니다. ex) isCustomer 또는 isCounselor
- 현재 결제 플로우가 확정되지 않아 ConsultRespository에서 consult를 가져올 때 isPay, isRefund 값을 고려하지 않았습니다. 추후 확정 시 수정하겠습니다.

피그마가 결제 api 포함 기준이라 구현할 때 좀 애매한 부분들이 생기네요...ㅠㅠ