### PR TITLE
#1 feat: 상담 신청 기능 수정

### DIFF
--- a/src/main/java/com/example/sharemind/consult/application/ConsultService.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultService.java
@@ -7,7 +7,7 @@ import com.example.sharemind.consult.dto.request.GetConsultRequest;
 import com.example.sharemind.consult.dto.response.ConsultResponse;
 
 public interface ConsultService {
-    UUID createConsult(CreateConsultRequest createConsultRequest);
+    void createConsult(CreateConsultRequest createConsultRequest);
 
     ConsultResponse getConsult(UUID consultUuid, GetConsultRequest getConsultRequest);
 }

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -6,11 +6,13 @@ import com.example.sharemind.consult.dto.request.GetConsultRequest;
 import com.example.sharemind.consult.dto.response.ConsultResponse;
 import com.example.sharemind.consult.exception.ConsultNotFoundException;
 import com.example.sharemind.consult.exception.IncorrectPasswordException;
+import com.example.sharemind.consult.mapper.ConsultMapper;
 import com.example.sharemind.consult.repository.ConsultRepository;
 import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.counselor.exception.CounselorNotFoundException;
 import com.example.sharemind.counselor.repository.CounselorRepository;
 import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.customer.mapper.CustomerMapper;
 import com.example.sharemind.customer.repository.CustomerRepository;
 import com.example.sharemind.message.dto.response.MessageResponse;
 import com.example.sharemind.message.repository.MessageRepository;
@@ -31,18 +33,19 @@ public class ConsultServiceImpl implements ConsultService {
     private final ConsultRepository consultRepository;
     private final MessageRepository messageRepository;
 
+    private final CustomerMapper customerMapper;
+    private final ConsultMapper consultMapper;
+
     @Override
     @Transactional
-    public UUID createConsult(CreateConsultRequest createConsultRequest) {
+    public void createConsult(CreateConsultRequest createConsultRequest) {
 
         Counselor counselor = counselorRepository.findById(createConsultRequest.getCounselorId())
                 .orElseThrow(() -> new CounselorNotFoundException(createConsultRequest.getCounselorId()));
 
-        Customer customer = customerRepository.save(createConsultRequest.toCustomer());
+        Customer customer = customerRepository.save(customerMapper.toEntity(createConsultRequest.getEmail()));
 
-        Consult consult = consultRepository.save(createConsultRequest.toConsult(customer, counselor));
-
-        return consult.getConsultUuid();
+        Consult consult = consultRepository.save(consultMapper.toEntity(customer, counselor));
     }
 
     @Override

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -31,22 +31,26 @@ public class Consult extends BaseEntity {
 
     private UUID consultUuid;
 
-    private String password;
+    private Long customerPassword;
+
+    private Long counselorPassword;
 
     private Boolean isPay;
 
     private Boolean isRefund;
 
-    private Boolean isReply;
+    private Boolean isActivated;
 
     @Builder
-    public Consult(Customer customer, Counselor counselor, UUID consultUuid, String password, Boolean isPay, Boolean isRefund, Boolean isReply) {
+    public Consult(Customer customer, Counselor counselor, UUID consultUuid, Long customerPassword, Long counselorPassword,
+                   Boolean isPay, Boolean isRefund, Boolean isActivated) {
         this.customer = customer;
         this.counselor = counselor;
         this.consultUuid = consultUuid;
-        this.password = password;
+        this.customerPassword = customerPassword;
+        this.counselorPassword = counselorPassword;
         this.isPay = isPay;
         this.isRefund = isRefund;
-        this.isReply = isReply;
+        this.isActivated = isActivated;
     }
 }

--- a/src/main/java/com/example/sharemind/consult/dto/request/CreateConsultRequest.java
+++ b/src/main/java/com/example/sharemind/consult/dto/request/CreateConsultRequest.java
@@ -1,42 +1,10 @@
 package com.example.sharemind.consult.dto.request;
 
-import com.example.sharemind.consult.domain.Consult;
-import com.example.sharemind.counselor.domain.Counselor;
-import com.example.sharemind.customer.domain.Customer;
 import lombok.Getter;
-
-import java.util.Random;
-import java.util.UUID;
 
 @Getter
 public class CreateConsultRequest {
 
     private Long counselorId;
     private String email;
-    private String name;
-    private String phoneNumber;
-    private String accountNumber;
-    private String password;
-
-    public Customer toCustomer() {
-        return Customer.builder()
-                .nickname("사용자" + new Random().nextInt(9999))
-                .email(email)
-                .name(name)
-                .phoneNumber(phoneNumber)
-                .accountNumber(accountNumber)
-                .build();
-    }
-
-    public Consult toConsult(Customer customer, Counselor counselor) {
-        return Consult.builder()
-                .customer(customer)
-                .counselor(counselor)
-                .consultUuid(UUID.randomUUID())
-                .password(password)
-                .isPay(false)
-                .isRefund(false)
-                .isReply(false)
-                .build();
-    }
 }

--- a/src/main/java/com/example/sharemind/consult/mapper/ConsultMapper.java
+++ b/src/main/java/com/example/sharemind/consult/mapper/ConsultMapper.java
@@ -1,0 +1,26 @@
+package com.example.sharemind.consult.mapper;
+
+import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.customer.domain.Customer;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+import java.util.UUID;
+
+@Component
+public class ConsultMapper {
+
+    public Consult toEntity(Customer customer, Counselor counselor) {
+        return Consult.builder()
+                .customer(customer)
+                .counselor(counselor)
+                .consultUuid(UUID.randomUUID())
+                .customerPassword(new Random().nextLong(1000000000L, 10000000000L))
+                .counselorPassword(new Random().nextLong(1000000000L, 10000000000L))
+                .isPay(false)
+                .isRefund(false)
+                .isActivated(true)
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
+++ b/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/v0/consult")
+@RequestMapping("/api/v0/consults")
 @RequiredArgsConstructor
 public class ConsultController {
 

--- a/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
+++ b/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
@@ -21,8 +21,11 @@ public class ConsultController {
     private final EmailService emailService;
 
     @PostMapping
-    public ResponseEntity<UUID> createConsult(@RequestBody CreateConsultRequest createConsultRequest) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(consultService.createConsult(createConsultRequest));
+    public ResponseEntity<Void> createConsult(@RequestBody CreateConsultRequest createConsultRequest) {
+
+        consultService.createConsult(createConsultRequest);
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @GetMapping("/{consultUuid}")

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v0/counselor")
+@RequestMapping("/api/v0/counselors")
 @RequiredArgsConstructor
 public class CounselorController {
 

--- a/src/main/java/com/example/sharemind/customer/domain/Customer.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Customer.java
@@ -28,11 +28,8 @@ public class Customer extends BaseEntity {
     private String accountNumber;
 
     @Builder
-    public Customer(String nickname, String email, String name, String phoneNumber, String accountNumber) {
+    public Customer(String nickname, String email) {
         this.nickname = nickname;
         this.email = email;
-        this.name = name;
-        this.phoneNumber = phoneNumber;
-        this.accountNumber = accountNumber;
     }
 }

--- a/src/main/java/com/example/sharemind/customer/mapper/CustomerMapper.java
+++ b/src/main/java/com/example/sharemind/customer/mapper/CustomerMapper.java
@@ -1,0 +1,17 @@
+package com.example.sharemind.customer.mapper;
+
+import com.example.sharemind.customer.domain.Customer;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Component
+public class CustomerMapper {
+
+    public Customer toEntity(String email) {
+        return Customer.builder()
+                .nickname("사용자" + new Random().nextInt(9999))
+                .email(email)
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/global/common/BaseEntity.java
+++ b/src/main/java/com/example/sharemind/global/common/BaseEntity.java
@@ -18,5 +18,5 @@ public class BaseEntity {
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updateAt;
+    private LocalDateTime updatedAt;
 }


### PR DESCRIPTION
## 📄구현 내용
- 사용자 이메일만 입력받도록 CreateConsultRequest 수정
- 비밀번호 랜덤 생성 추가 (10자리 숫자)
- createConsult 실행 완료 시 상태코드만 반환하도록 수정
- Consult 엔티티 필드 수정
- ConsultMapper, CustomerMapper 생성

## 📝기타 알림사항
- 수정 반영하여 createConsult api 문서도 수정하였습니다.
- Consult 엔티티 필드 수정 erd에도 반영하였습니다.
- 기존에는 createConsult에서 consult, customer 객체 생성 시 createConsultRequest에 메서드를 두고 생성하였습니다. 그러나 consult와 customer 모두 객체 생성 과정에서 단순히 값을 넘겨받아 생성하는 것이 아니라 필드 값을 생성하는 로직(random~)이 있다는 점, consult의 경우 createConsultRequest의 필드 값을 그대로 사용하여 생성하는 것이 아니라는 점에서 dto에서 갖고 있을만한 역할이 아니라고 생각하여 따로 mapper를 생성하였습니다.
- BaseEntity 필드에 오타 발견하여 수정하였습니다. (updateAt -> updatedAt)
- consult, counselor 부분 url 수정하였습니다. (/api/v0/consult -> /api/v0/consults, /api/v0/counselor -> /api/v0/counselors)