### PR TITLE
#10 feat: 관리페이지 구현

### DIFF
--- a/src/main/java/com/example/sharemind/admin/application/AdminService.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminService.java
@@ -1,0 +1,12 @@
+package com.example.sharemind.admin.application;
+
+import com.example.sharemind.admin.dto.response.AdminResponse;
+
+import java.util.List;
+
+public interface AdminService {
+
+    List<AdminResponse> getConsultsByIsPayFalse(String password);
+
+    void updateIsPayTrue(Long consultId);
+}

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -1,0 +1,54 @@
+package com.example.sharemind.admin.application;
+
+import com.example.sharemind.admin.dto.response.AdminResponse;
+import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.consult.exception.ConsultNotFoundException;
+import com.example.sharemind.consult.repository.ConsultRepository;
+import com.example.sharemind.email.application.EmailService;
+import com.example.sharemind.email.application.content.EmailTypes;
+import com.example.sharemind.global.exception.IncorrectPasswordException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminServiceImpl implements AdminService {
+
+    @Value("${admin.password}")
+    private String ADMIN_PASSWORD;
+
+    private final ConsultRepository consultRepository;
+    private final EmailService emailService;
+
+    @Override
+    public List<AdminResponse> getConsultsByIsPayFalse(String password) {
+
+        if (!ADMIN_PASSWORD.equals(password)) {
+            throw new IncorrectPasswordException();
+        }
+
+        List<AdminResponse> adminResponses = consultRepository.findAllByIsPayAndIsActivated(false, true)
+                .stream()
+                .map(AdminResponse::from)
+                .toList();
+
+        return adminResponses;
+    }
+
+    @Override
+    @Transactional
+    public void updateIsPayTrue(Long consultId) {
+
+        Consult consult = consultRepository.findByConsultIdAndIsPayAndIsActivated(consultId, false, true)
+                .orElseThrow(() -> new ConsultNotFoundException(consultId));
+
+        consult.updateIsPayToTrue();
+
+        emailService.sendEmailToCustomer(consult, EmailTypes.LINK);
+    }
+}

--- a/src/main/java/com/example/sharemind/admin/dto/response/AdminResponse.java
+++ b/src/main/java/com/example/sharemind/admin/dto/response/AdminResponse.java
@@ -27,7 +27,7 @@ public class AdminResponse {
                 .consultId(consult.getConsultId())
                 .customerEmail(consult.getCustomer().getEmail())
                 .counselorEmail(consult.getCounselor().getEmail())
-                .createdAt(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(consult.getCreatedAt()))
+                .createdAt(DateTimeFormatter.ofPattern("MM-dd HH:mm").format(consult.getCreatedAt()))
                 .build();
     }
 }

--- a/src/main/java/com/example/sharemind/admin/dto/response/AdminResponse.java
+++ b/src/main/java/com/example/sharemind/admin/dto/response/AdminResponse.java
@@ -1,0 +1,33 @@
+package com.example.sharemind.admin.dto.response;
+
+import com.example.sharemind.consult.domain.Consult;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+public class AdminResponse {
+
+    private final Long consultId;
+    private final String customerEmail;
+    private final String counselorEmail;
+    private final String createdAt;
+
+    @Builder
+    public AdminResponse(Long consultId, String customerEmail, String counselorEmail, String createdAt) {
+        this.consultId = consultId;
+        this.customerEmail = customerEmail;
+        this.counselorEmail = counselorEmail;
+        this.createdAt = createdAt;
+    }
+
+    public static AdminResponse from(Consult consult) {
+        return AdminResponse.builder()
+                .consultId(consult.getConsultId())
+                .customerEmail(consult.getCustomer().getEmail())
+                .counselorEmail(consult.getCounselor().getEmail())
+                .createdAt(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(consult.getCreatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
@@ -1,0 +1,30 @@
+package com.example.sharemind.admin.presentation;
+
+import com.example.sharemind.admin.application.AdminService;
+import com.example.sharemind.admin.dto.response.AdminResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v0/admins")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @GetMapping
+    public ResponseEntity<List<AdminResponse>> getConsultsByIsPayFalse(@RequestParam String password) {
+        return ResponseEntity.ok(adminService.getConsultsByIsPayFalse(password));
+    }
+
+    @PatchMapping("/{consultId}")
+    public ResponseEntity<Void> updateIsPayTrue(@PathVariable Long consultId) {
+
+        adminService.updateIsPayTrue(consultId);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -5,7 +5,7 @@ import com.example.sharemind.consult.dto.request.CreateConsultRequest;
 import com.example.sharemind.consult.dto.request.GetConsultRequest;
 import com.example.sharemind.consult.dto.response.GetConsultResponse;
 import com.example.sharemind.consult.exception.ConsultNotFoundException;
-import com.example.sharemind.consult.exception.IncorrectPasswordException;
+import com.example.sharemind.global.exception.IncorrectPasswordException;
 import com.example.sharemind.consult.mapper.ConsultMapper;
 import com.example.sharemind.consult.repository.ConsultRepository;
 import com.example.sharemind.counselor.domain.Counselor;
@@ -45,7 +45,7 @@ public class ConsultServiceImpl implements ConsultService {
 
         Customer customer = customerRepository.save(customerMapper.toEntity(createConsultRequest.getEmail()));
 
-        Consult consult = consultRepository.save(consultMapper.toEntity(customer, counselor));
+        consultRepository.save(consultMapper.toEntity(customer, counselor));
     }
 
     @Override

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -53,4 +53,8 @@ public class Consult extends BaseEntity {
         this.isRefund = isRefund;
         this.isActivated = isActivated;
     }
+
+    public void updateIsPayToTrue() {
+        this.isPay = true;
+    }
 }

--- a/src/main/java/com/example/sharemind/consult/dto/response/GetConsultResponse.java
+++ b/src/main/java/com/example/sharemind/consult/dto/response/GetConsultResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 public class GetConsultResponse {
 
     private final Long consultId;
-
     private final Boolean loginByCustomer;
     private final String customerNickname;
     private final String counselorNickname;

--- a/src/main/java/com/example/sharemind/consult/presentation/ConsultExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/consult/presentation/ConsultExceptionHandler.java
@@ -2,7 +2,6 @@ package com.example.sharemind.consult.presentation;
 
 
 import com.example.sharemind.consult.exception.ConsultNotFoundException;
-import com.example.sharemind.consult.exception.IncorrectPasswordException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,11 +15,5 @@ public class ConsultExceptionHandler {
     public ResponseEntity<String> catchConsultNotFoundException(ConsultNotFoundException e) {
         log.error(e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-    }
-
-    @ExceptionHandler(IncorrectPasswordException.class)
-    public ResponseEntity<String> catchIncorrectPasswordException(IncorrectPasswordException e) {
-        log.error(e.getMessage());
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
     }
 }

--- a/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
+++ b/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
@@ -1,6 +1,8 @@
 package com.example.sharemind.consult.repository;
 
 import com.example.sharemind.consult.domain.Consult;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +13,8 @@ public interface ConsultRepository extends JpaRepository<Consult, Long> {
     Optional<Consult> findByConsultId(Long consultId);
 
     Optional<Consult> findByConsultUuidAndIsPayAndIsActivated(UUID consultUuid, Boolean isPay, Boolean isActivated);
+
+    Optional<Consult> findByConsultIdAndIsPayAndIsActivated(Long consultId, Boolean isPay, Boolean isActivated);
+
+    List<Consult> findAllByIsPayAndIsActivated(Boolean isPay, Boolean isActivated);
 }

--- a/src/main/java/com/example/sharemind/global/exception/IncorrectPasswordException.java
+++ b/src/main/java/com/example/sharemind/global/exception/IncorrectPasswordException.java
@@ -1,4 +1,4 @@
-package com.example.sharemind.consult.exception;
+package com.example.sharemind.global.exception;
 
 public class IncorrectPasswordException extends RuntimeException {
 

--- a/src/main/java/com/example/sharemind/global/presentation/GlobalExceptionController.java
+++ b/src/main/java/com/example/sharemind/global/presentation/GlobalExceptionController.java
@@ -1,0 +1,19 @@
+package com.example.sharemind.global.presentation;
+
+import com.example.sharemind.global.exception.IncorrectPasswordException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionController {
+
+    @ExceptionHandler(IncorrectPasswordException.class)
+    public ResponseEntity<String> catchIncorrectPasswordException(IncorrectPasswordException e) {
+        log.error(e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    }
+}


### PR DESCRIPTION
## 📄구현 내용
- 미결제 목록 조회 api
- 결제 상태 변경 api
- 결제 완료로 상태 변경 후 상담 링크 안내 이메일 발송

## 📝기타 알림사항
- 구현 내용 노션 api 문서에 작성해두었습니다.
- password 설정 노션 yml 문서에 추가해두었습니다.
- IncorrectPasswordException을 관리페이지 진입 시에도 사용하게 되어 패키지 위치 global.exception으로 이동하였습니다.
- 관리페이지의 경우, 팀원들끼리만 공유하는 페이지이기 때문에 비밀번호 입력을 requestParam으로 간단하게 설정하였습니다.
- 현재 피그마 상에서는 결제 완료 시 사용자, 상담사 모두에게 이메일 발송하는 것으로 되어있는데 결제 완료 직후에는 사용자에게 상담 링크 안내 -> 사용자가 상담 내용 입력 -> 상담사가 확인 후 답변 입력의 플로우가 맞는 것 같아 사용자에게만 이메일 발송하는 것으로 설정해두었습니다. 기획 파트 피드백 필요할 것 같습니다.