### PR TITLE
#6 feat: 결제 후 상담 정상 진행 여부 확인 로직 구현

### DIFF
--- a/src/main/java/com/example/sharemind/SharemindApplication.java
+++ b/src/main/java/com/example/sharemind/SharemindApplication.java
@@ -3,8 +3,10 @@ package com.example.sharemind;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class SharemindApplication {
 

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -107,11 +107,12 @@ public class ConsultServiceImpl implements ConsultService {
 
             consult.updateIsRefundToTrue();
         } else {
-            if (messages.size() == 2) {
-                emailService.sendEmailToCustomer(consult, EmailTypes.CUSTOMER_NO_ADDITIONAL_QUESTION);
-                emailService.sendEmailToCounselor(consult, EmailTypes.COUNSELOR_NO_ADDITIONAL_QUESTION);
-            } else {
-                emailService.sendEmailToCounselor(consult, EmailTypes.COUNSELOR_CLOSURE);
+            switch (messages.size()) {
+                case 2 -> {
+                    emailService.sendEmailToCustomer(consult, EmailTypes.CUSTOMER_NO_ADDITIONAL_QUESTION);
+                    emailService.sendEmailToCounselor(consult, EmailTypes.COUNSELOR_NO_ADDITIONAL_QUESTION);
+                }
+                case 4 -> emailService.sendEmailToCounselor(consult, EmailTypes.COUNSELOR_CLOSURE);
             }
         }
 

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -5,6 +5,8 @@ import com.example.sharemind.consult.dto.request.CreateConsultRequest;
 import com.example.sharemind.consult.dto.request.GetConsultRequest;
 import com.example.sharemind.consult.dto.response.GetConsultResponse;
 import com.example.sharemind.consult.exception.ConsultNotFoundException;
+import com.example.sharemind.email.application.EmailService;
+import com.example.sharemind.email.application.content.EmailTypes;
 import com.example.sharemind.global.exception.IncorrectPasswordException;
 import com.example.sharemind.consult.mapper.ConsultMapper;
 import com.example.sharemind.consult.repository.ConsultRepository;
@@ -14,12 +16,16 @@ import com.example.sharemind.counselor.repository.CounselorRepository;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.customer.mapper.CustomerMapper;
 import com.example.sharemind.customer.repository.CustomerRepository;
+import com.example.sharemind.message.domain.Message;
 import com.example.sharemind.message.dto.response.MessageResponse;
 import com.example.sharemind.message.repository.MessageRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -27,6 +33,8 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ConsultServiceImpl implements ConsultService {
+
+    private final EmailService emailService;
 
     private final CustomerRepository customerRepository;
     private final CounselorRepository counselorRepository;
@@ -70,5 +78,43 @@ public class ConsultServiceImpl implements ConsultService {
                 .toList();
 
         return GetConsultResponse.from(loginByCustomer, consult, messageResponses);
+    }
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void checkConsults() {
+
+        LocalDateTime currentTime = LocalDateTime.now();
+
+        consultRepository.findAllByIsPayAndIsActivated(true, true)
+                .stream()
+                .filter(consult -> {
+                    List<Message> messages = messageRepository.findAllByConsult(consult, Sort.by(Sort.Direction.DESC, "createdAt"));
+                    return !messages.isEmpty() && messages.get(0).getCreatedAt().plusHours(24).isBefore(currentTime);
+                })
+                .forEach(this::checkIsReply);
+    }
+
+
+    private void checkIsReply(Consult consult) {
+
+        List<Message> messages = messageRepository.findAllByConsult(consult, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Message lastMessage = messages.get(0);
+
+        if (lastMessage.getIsCustomer()) {
+            emailService.sendEmailToCustomer(consult, EmailTypes.CUSTOMER_CANCEL);
+            emailService.sendEmailToCounselor(consult, EmailTypes.COUNSELOR_CANCEL);
+
+            consult.updateIsRefundToTrue();
+        } else {
+            if (messages.size() == 2) {
+                emailService.sendEmailToCustomer(consult, EmailTypes.CUSTOMER_NO_ADDITIONAL_QUESTION);
+                emailService.sendEmailToCounselor(consult, EmailTypes.COUNSELOR_NO_ADDITIONAL_QUESTION);
+            } else {
+                emailService.sendEmailToCounselor(consult, EmailTypes.COUNSELOR_CLOSURE);
+            }
+        }
+
+        consult.updateIsActivatedToFalse();
     }
 }

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -57,4 +57,12 @@ public class Consult extends BaseEntity {
     public void updateIsPayToTrue() {
         this.isPay = true;
     }
+
+    public void updateIsRefundToTrue() {
+        this.isRefund = true;
+    }
+
+    public void updateIsActivatedToFalse() {
+        this.isActivated = false;
+    }
 }

--- a/src/main/java/com/example/sharemind/message/repository/MessageRepository.java
+++ b/src/main/java/com/example/sharemind/message/repository/MessageRepository.java
@@ -2,6 +2,7 @@ package com.example.sharemind.message.repository;
 
 import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.message.domain.Message;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +12,8 @@ import java.util.List;
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
     List<Message> findAllByConsult(Consult consult);
+
+    List<Message> findAllByConsult(Consult consult, Sort sort);
 
     boolean existsByConsultAndIsCustomer(Consult consult, boolean isCustomer);
 }


### PR DESCRIPTION
## 📄구현 내용
- 결제 후 상담 정상 진행 여부 주기적(매일 오전 12시)으로 확인 후 처리

## 📝기타 알림사항
- 로직 동작 순서는 다음과 같습니다.
1. 결제 완료 상태인 상담 전체 조회
2. 각 상담에 대해 메시지 목록 내림차순으로 조회 (get(0)으로 가장 최근 메시지 꺼내기 위해)
3. 제일 처음 조회된 메시지의 생성시간이 24시간을 지났는지 체크
4. 24시간 지난 경우, 제일 처음 조회된 메시지 전송자가 누구인지 체크
4-1. 사용자인 경우, 상담 환불 및 customer_cancel, counselor_cancel
4-2. 상담사인 경우, 메시지 2개면 no_additional_question, 4개면 counselor_closure
4-3. 상담 비활성화